### PR TITLE
feat: format files

### DIFF
--- a/_tasks/e2e.sh
+++ b/_tasks/e2e.sh
@@ -6,11 +6,28 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TEMPLATE_DIR="$DIR"/..
 ANSWERS_FILE=.copier-answers.yml
 
+fail() {
+  local message="$1"
+
+  echo "$message" >&2
+  exit 1
+}
+
 tempRepo="$(mktemp -d "${TMPDIR:-/tmp}/flask-template.e2e.XXXXXX")"
 
-#trap 'rm -rf "${tempRepo}"' EXIT
+if [[ -z ${E2E_DEBUG:-} ]]; then
+  trap 'rm -rf "${tempRepo}"' EXIT
+fi
 cp "$DIR/$ANSWERS_FILE" "$tempRepo"
 echo "_src_path: \"$TEMPLATE_DIR\"" >>"$tempRepo/$ANSWERS_FILE"
 
+mise trust "$tempRepo/mise.toml"
+trap 'mise trust --untrust "$tempRepo/mise.toml"' EXIT
+
 echo "E2E: Running copier to destination '$tempRepo'"
 copier recopy --skip-answered --trust "$tempRepo"
+
+readmeLength="$(wc -c "$tempRepo"/README.md | awk '{print $1}')"
+if [[ "$readmeLength" != 0 ]]; then
+  fail "Expected empty README.md from 'uv init', got $readmeLength characters"
+fi

--- a/copier.yml
+++ b/copier.yml
@@ -15,7 +15,6 @@ _exclude:
   - .github
   - _tasks
   - copier.yml
-  - mise.toml
   - README.md
 
 _tasks:
@@ -34,3 +33,4 @@ _tasks:
   - [uv, add, Flask, mistune]
   - [uv, add, "--dev", "--extra", "faster-cache", "mypy"]
   - ["{{ _copier_python }}", "{{ _copier_conf.src_path }}{{ _copier_conf.sep }}_tasks{{ _copier_conf.sep }}augment_project.py"]
+  - [mise, run, fmt]


### PR DESCRIPTION
Format the generated files at the end of the build process.

In the process, make sure that the `mise` tasks are properly copied to the new repo.

Also adds a basic test that there is an empty `README.md` in the new repo.